### PR TITLE
refactor: ray executor without tool change

### DIFF
--- a/plexe/internal/agents.py
+++ b/plexe/internal/agents.py
@@ -16,7 +16,7 @@ from plexe.config import config
 from plexe.internal.models.entities.artifact import Artifact
 from plexe.internal.models.entities.code import Code
 from plexe.internal.models.tools.evaluation import review_finalised_model
-from plexe.internal.models.tools.execution import execute_training_code
+from plexe.internal.models.tools.execution import get_executor_tool
 from plexe.internal.models.tools.code_generation import (
     generate_inference_code,
     fix_inference_code,
@@ -68,6 +68,7 @@ class PlexeAgent:
         ml_ops_engineer_model_id: str = "anthropic/claude-3-7-sonnet-20250219",
         verbose: bool = False,
         max_steps: int = 30,
+        distributed: bool = False,
     ):
         """
         Initialize the multi-agent ML engineering system.
@@ -76,6 +77,7 @@ class PlexeAgent:
             orchestrator_model_id: Model ID for the orchestrator agent
             verbose: Whether to display detailed agent logs
             max_steps: Maximum number of steps for the orchestrator agent
+            distributed: Whether to run the agents in a distributed environment
         """
         self.orchestrator_model_id = orchestrator_model_id
         self.ml_researcher_model_id = ml_researcher_model_id
@@ -83,6 +85,7 @@ class PlexeAgent:
         self.ml_ops_engineer_model_id = ml_ops_engineer_model_id
         self.verbose = verbose
         self.max_steps = max_steps
+        self.distributed = distributed
 
         # Set verbosity levels
         self.orchestrator_verbosity = 2 if verbose else 1
@@ -127,7 +130,7 @@ class PlexeAgent:
                 generate_training_code,
                 validate_training_code,
                 fix_training_code,
-                execute_training_code,
+                get_executor_tool(distributed),
                 format_final_mle_agent_response,
             ],
             add_base_tools=False,

--- a/plexe/internal/models/tools/execution.py
+++ b/plexe/internal/models/tools/execution.py
@@ -7,7 +7,7 @@ ensuring that artifacts generated during the execution can be retrieved later in
 
 import logging
 import uuid
-from typing import Dict, List
+from typing import Dict, List, Callable
 
 from smolagents import tool
 
@@ -24,7 +24,200 @@ from typing import Type
 logger = logging.getLogger(__name__)
 
 
-def get_executor_class(distributed: bool = False) -> Type:
+def get_executor_tool(distributed: bool = False) -> Callable:
+    """Get the appropriate executor tool based on the distributed flag."""
+
+    @tool
+    def execute_training_code(
+        node_id: str,
+        code: str,
+        working_dir: str,
+        dataset_names: List[str],
+        timeout: int,
+        metric_to_optimise_name: str,
+        metric_to_optimise_comparison_method: str,
+    ) -> Dict:
+        """Executes training code in an isolated environment.
+
+        Args:
+            node_id: Unique identifier for this execution
+            code: The code to execute
+            working_dir: Directory to use for execution
+            dataset_names: List of dataset names to retrieve from the registry
+            timeout: Maximum execution time in seconds
+            metric_to_optimise_name: The name of the metric to optimize for
+            metric_to_optimise_comparison_method: The comparison method for the metric
+
+        Returns:
+            A dictionary containing execution results with model artifacts and their registry names
+        """
+        # Log the distributed flag
+        logger.info(f"execute_training_code called with distributed={distributed}")
+
+        from plexe.callbacks import BuildStateInfo
+
+        object_registry = ObjectRegistry()
+
+        execution_id = f"{node_id}-{uuid.uuid4()}"
+        try:
+            # Get actual datasets from registry
+            datasets = object_registry.get_multiple(TabularConvertible, dataset_names)
+
+            # Convert string to enum if needed
+            if "HIGHER_IS_BETTER" in metric_to_optimise_comparison_method:
+                comparison_method = ComparisonMethod.HIGHER_IS_BETTER
+            elif "LOWER_IS_BETTER" in metric_to_optimise_comparison_method:
+                comparison_method = ComparisonMethod.LOWER_IS_BETTER
+            elif "TARGET_IS_BETTER" in metric_to_optimise_comparison_method:
+                comparison_method = ComparisonMethod.TARGET_IS_BETTER
+            else:
+                comparison_method = ComparisonMethod.HIGHER_IS_BETTER
+
+            # Create a node to store execution results
+            node = Node(solution_plan="")  # We only need this for execute_node
+
+            # Get callbacks from the registry and notify them
+            node.training_code = code
+            # Notification for iteration end with all required fields
+            for callback in object_registry.get_all(Callback).values():
+                try:
+                    callback.on_iteration_start(
+                        BuildStateInfo(
+                            intent="goobers",  # Will be filled by agent context
+                            provider="openai/gpt-4o",  # Will be filled by agent context
+                            input_schema=None,  # Will be filled by agent context
+                            output_schema=None,  # Will be filled by agent context
+                            datasets=datasets,
+                            iteration=0,  # Default value, no longer used for MLFlow run naming
+                            node=node,
+                        )
+                    )
+                except Exception as e:
+                    logger.warning(f"Error in callback {callback.__class__.__name__}.on_iteration_end: {e}")
+
+            # Import here to avoid circular imports
+            from plexe.config import config
+
+            # Get the appropriate executor class via the factory
+            executor_class = _get_executor_class(distributed=distributed)
+
+            # Create an instance of the executor
+            logger.info(f"Creating {executor_class.__name__} for execution ID: {execution_id}")
+            executor = executor_class(
+                execution_id=execution_id,
+                code=code,
+                working_dir=working_dir,
+                datasets=datasets,
+                timeout=timeout,
+                code_execution_file_name=config.execution.runfile_name,
+            )
+
+            logger.debug(f"Executing node {node} using executor {executor}")
+            result = executor.run()
+            logger.debug(f"Execution result: {result}")
+            node.execution_time = result.exec_time
+            node.execution_stdout = result.term_out
+            node.exception_was_raised = result.exception is not None
+            node.exception = result.exception or None
+            node.model_artifacts = result.model_artifacts
+
+            # Handle the performance metric properly
+            performance_value = None
+            is_worst = True
+
+            if result.performance is not None and isinstance(result.performance, (int, float)):
+                performance_value = result.performance
+                is_worst = False
+
+                if (
+                    result.performance
+                    in [float("inf"), float("-inf")]
+                    # or result.performance < 1e-7
+                    # or result.performance > 1 - 1e-7
+                ):
+                    performance_value = None
+                    is_worst = True
+
+            # Create a metric object with proper handling of None or invalid values
+            node.performance = Metric(
+                name=metric_to_optimise_name,
+                value=performance_value,
+                comparator=MetricComparator(comparison_method=comparison_method),
+                is_worst=is_worst,
+            )
+
+            node.training_code = code
+
+            # Notify callbacks about the execution end
+            # Notification for iteration end with all required fields
+            for callback in object_registry.get_all(Callback).values():
+                try:
+                    # Create build state info with required fields
+                    # Some fields like intent, input_schema, etc. will be empty here
+                    # but will be filled in by the model builder agent context
+                    callback.on_iteration_end(
+                        BuildStateInfo(
+                            intent="goobers",  # Will be filled by agent context
+                            provider="openai/gpt-4o",  # Will be filled by agent context
+                            input_schema=None,  # Will be filled by agent context
+                            output_schema=None,  # Will be filled by agent context
+                            datasets=datasets,
+                            iteration=0,  # Default value, no longer used for MLFlow run naming
+                            node=node,
+                        )
+                    )
+                except Exception as e:
+                    logger.warning(f"Error in callback {callback.__class__.__name__}.on_iteration_end: {e}")
+
+            # Check if the execution failed in any way
+            if node.exception is not None:
+                raise RuntimeError(f"Execution failed with exception: {node.exception}")
+            if (
+                result.performance is None
+                or not isinstance(result.performance, (int, float))
+                or result.performance in [float("inf"), float("-inf")]
+                # or result.performance < 1e-7
+                # or result.performance > 1 - 1e-7
+            ):
+                raise RuntimeError(f"Execution failed due to not producing a valid performance: {result.performance}")
+
+            # Register code and artifacts
+            artifact_paths = node.model_artifacts if node.model_artifacts else []
+            artifacts = [Artifact.from_path(p) for p in artifact_paths]
+            object_registry.register_multiple(Artifact, {a.name: a for a in artifacts})
+            object_registry.register(Code, execution_id, Code(node.training_code))
+
+            # Return results
+            return {
+                "success": not node.exception_was_raised,
+                "performance": (
+                    {
+                        "name": node.performance.name if node.performance else None,
+                        "value": node.performance.value if node.performance else None,
+                        "comparison_method": (
+                            str(node.performance.comparator.comparison_method) if node.performance else None
+                        ),
+                    }
+                    if node.performance
+                    else None
+                ),
+                "exception": str(node.exception) if node.exception else None,
+                "model_artifact_names": [a.name for a in artifacts],
+                "training_code_id": execution_id,
+            }
+        except Exception as e:
+            logger.error(f"Error executing training code: {str(e)}")
+            return {
+                "success": False,
+                "performance": None,
+                "exception": str(e),
+                "model_artifact_names": [],
+            }
+
+    return execute_training_code
+
+
+def _get_executor_class(distributed: bool = False) -> Type:
     """Get the appropriate executor class based on the distributed flag.
 
     Args:
@@ -50,193 +243,3 @@ def get_executor_class(distributed: bool = False) -> Type:
     # Default to ProcessExecutor for non-distributed execution
     logger.info("Using ProcessExecutor (non-distributed)")
     return ProcessExecutor
-
-
-@tool
-def execute_training_code(
-    node_id: str,
-    code: str,
-    working_dir: str,
-    dataset_names: List[str],
-    timeout: int,
-    metric_to_optimise_name: str,
-    metric_to_optimise_comparison_method: str,
-    distributed: bool = False,
-) -> Dict:
-    """Executes training code in an isolated environment.
-
-    Args:
-        node_id: Unique identifier for this execution
-        code: The code to execute
-        working_dir: Directory to use for execution
-        dataset_names: List of dataset names to retrieve from the registry
-        timeout: Maximum execution time in seconds
-        metric_to_optimise_name: The name of the metric to optimize for
-        metric_to_optimise_comparison_method: The comparison method for the metric
-        distributed: Whether to use distributed execution with Ray (default: False)
-
-    Returns:
-        A dictionary containing execution results with model artifacts and their registry names
-    """
-    # Log the distributed flag
-    logger.info(f"execute_training_code called with distributed={distributed}")
-
-    from plexe.callbacks import BuildStateInfo
-
-    object_registry = ObjectRegistry()
-
-    execution_id = f"{node_id}-{uuid.uuid4()}"
-    try:
-        # Get actual datasets from registry
-        datasets = object_registry.get_multiple(TabularConvertible, dataset_names)
-
-        # Convert string to enum if needed
-        if "HIGHER_IS_BETTER" in metric_to_optimise_comparison_method:
-            comparison_method = ComparisonMethod.HIGHER_IS_BETTER
-        elif "LOWER_IS_BETTER" in metric_to_optimise_comparison_method:
-            comparison_method = ComparisonMethod.LOWER_IS_BETTER
-        elif "TARGET_IS_BETTER" in metric_to_optimise_comparison_method:
-            comparison_method = ComparisonMethod.TARGET_IS_BETTER
-        else:
-            comparison_method = ComparisonMethod.HIGHER_IS_BETTER
-
-        # Create a node to store execution results
-        node = Node(solution_plan="")  # We only need this for execute_node
-
-        # Get callbacks from the registry and notify them
-        node.training_code = code
-        # Notification for iteration end with all required fields
-        for callback in object_registry.get_all(Callback).values():
-            try:
-                callback.on_iteration_start(
-                    BuildStateInfo(
-                        intent="goobers",  # Will be filled by agent context
-                        provider="openai/gpt-4o",  # Will be filled by agent context
-                        input_schema=None,  # Will be filled by agent context
-                        output_schema=None,  # Will be filled by agent context
-                        datasets=datasets,
-                        iteration=0,  # Default value, no longer used for MLFlow run naming
-                        node=node,
-                    )
-                )
-            except Exception as e:
-                logger.warning(f"Error in callback {callback.__class__.__name__}.on_iteration_end: {e}")
-
-        # Import here to avoid circular imports
-        from plexe.config import config
-
-        # Get the appropriate executor class via the factory
-        executor_class = get_executor_class(distributed=distributed)
-
-        # Create an instance of the executor
-        logger.info(f"Creating {executor_class.__name__} for execution ID: {execution_id}")
-        executor = executor_class(
-            execution_id=execution_id,
-            code=code,
-            working_dir=working_dir,
-            datasets=datasets,
-            timeout=timeout,
-            code_execution_file_name=config.execution.runfile_name,
-        )
-
-        logger.debug(f"Executing node {node} using executor {executor}")
-        result = executor.run()
-        logger.debug(f"Execution result: {result}")
-        node.execution_time = result.exec_time
-        node.execution_stdout = result.term_out
-        node.exception_was_raised = result.exception is not None
-        node.exception = result.exception or None
-        node.model_artifacts = result.model_artifacts
-
-        # Handle the performance metric properly
-        performance_value = None
-        is_worst = True
-
-        if result.performance is not None and isinstance(result.performance, (int, float)):
-            performance_value = result.performance
-            is_worst = False
-
-            if (
-                result.performance
-                in [float("inf"), float("-inf")]
-                # or result.performance < 1e-7
-                # or result.performance > 1 - 1e-7
-            ):
-                performance_value = None
-                is_worst = True
-
-        # Create a metric object with proper handling of None or invalid values
-        node.performance = Metric(
-            name=metric_to_optimise_name,
-            value=performance_value,
-            comparator=MetricComparator(comparison_method=comparison_method),
-            is_worst=is_worst,
-        )
-
-        node.training_code = code
-
-        # Notify callbacks about the execution end
-        # Notification for iteration end with all required fields
-        for callback in object_registry.get_all(Callback).values():
-            try:
-                # Create build state info with required fields
-                # Some fields like intent, input_schema, etc. will be empty here
-                # but will be filled in by the model builder agent context
-                callback.on_iteration_end(
-                    BuildStateInfo(
-                        intent="goobers",  # Will be filled by agent context
-                        provider="openai/gpt-4o",  # Will be filled by agent context
-                        input_schema=None,  # Will be filled by agent context
-                        output_schema=None,  # Will be filled by agent context
-                        datasets=datasets,
-                        iteration=0,  # Default value, no longer used for MLFlow run naming
-                        node=node,
-                    )
-                )
-            except Exception as e:
-                logger.warning(f"Error in callback {callback.__class__.__name__}.on_iteration_end: {e}")
-
-        # Check if the execution failed in any way
-        if node.exception is not None:
-            raise RuntimeError(f"Execution failed with exception: {node.exception}")
-        if (
-            result.performance is None
-            or not isinstance(result.performance, (int, float))
-            or result.performance in [float("inf"), float("-inf")]
-            # or result.performance < 1e-7
-            # or result.performance > 1 - 1e-7
-        ):
-            raise RuntimeError(f"Execution failed due to not producing a valid performance: {result.performance}")
-
-        # Register code and artifacts
-        artifact_paths = node.model_artifacts if node.model_artifacts else []
-        artifacts = [Artifact.from_path(p) for p in artifact_paths]
-        object_registry.register_multiple(Artifact, {a.name: a for a in artifacts})
-        object_registry.register(Code, execution_id, Code(node.training_code))
-
-        # Return results
-        return {
-            "success": not node.exception_was_raised,
-            "performance": (
-                {
-                    "name": node.performance.name if node.performance else None,
-                    "value": node.performance.value if node.performance else None,
-                    "comparison_method": (
-                        str(node.performance.comparator.comparison_method) if node.performance else None
-                    ),
-                }
-                if node.performance
-                else None
-            ),
-            "exception": str(node.exception) if node.exception else None,
-            "model_artifact_names": [a.name for a in artifacts],
-            "training_code_id": execution_id,
-        }
-    except Exception as e:
-        logger.error(f"Error executing training code: {str(e)}")
-        return {
-            "success": False,
-            "performance": None,
-            "exception": str(e),
-            "model_artifact_names": [],
-        }

--- a/plexe/models.py
+++ b/plexe/models.py
@@ -247,6 +247,7 @@ class Model:
                 ml_ops_engineer_model_id=provider_config.ops_provider,
                 verbose=verbose,
                 max_steps=30,
+                distributed=self.distributed,
             )
             generated = agent.run(
                 agent_prompt,
@@ -259,7 +260,6 @@ class Model:
                     "max_iterations": max_iterations,
                     "timeout": timeout,
                     "run_timeout": run_timeout,
-                    "distributed": self.distributed,  # Pass distributed flag to tools
                 },
             )
 

--- a/tests/integration/test_ray_integration.py
+++ b/tests/integration/test_ray_integration.py
@@ -58,15 +58,14 @@ def test_model_with_ray(sample_dataset):
     assert model.metric is not None
 
     # Get executor classes
-    from plexe.internal.models.tools.execution import get_executor_class
+    from plexe.internal.models.tools.execution import _get_executor_class
     from plexe.internal.models.execution.ray_executor import RayExecutor
-    from plexe.internal.models.execution.process_executor import ProcessExecutor
 
     # Verify model has the distributed flag set
     assert model.distributed, "Model should have distributed=True"
 
     # Verify the factory would select RayExecutor when distributed=True
-    executor_class = get_executor_class(distributed=True)
+    executor_class = _get_executor_class(distributed=True)
     assert executor_class == RayExecutor, "Factory should return RayExecutor when distributed=True"
 
     # The logs show Ray is being used, but the flag might not be set when checked
@@ -75,4 +74,4 @@ def test_model_with_ray(sample_dataset):
 
     # Instead, verify our factory returns the right executor when asked
     # The logs confirm Ray is actually used
-    assert get_executor_class(distributed=True) == RayExecutor
+    assert _get_executor_class(distributed=True) == RayExecutor

--- a/tests/unit/internal/models/execution/test_factory.py
+++ b/tests/unit/internal/models/execution/test_factory.py
@@ -1,18 +1,17 @@
 """Test the executor factory."""
 
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import importlib
 
-from plexe.internal.models.tools.execution import get_executor_class
+from plexe.internal.models.tools.execution import _get_executor_class
 from plexe.internal.models.execution.process_executor import ProcessExecutor
-from plexe.config import config
 
 
 def test_get_executor_class_non_distributed():
     """Test that ProcessExecutor is returned when distributed=False."""
-    executor_class = get_executor_class(distributed=False)
+    executor_class = _get_executor_class(distributed=False)
     assert executor_class == ProcessExecutor
 
 
@@ -22,7 +21,7 @@ def test_get_executor_class_distributed():
     ray_available = importlib.util.find_spec("ray") is not None
 
     if ray_available:
-        executor_class = get_executor_class(distributed=True)
+        executor_class = _get_executor_class(distributed=True)
         from plexe.internal.models.execution.ray_executor import RayExecutor
 
         assert executor_class == RayExecutor
@@ -41,5 +40,5 @@ def test_get_executor_class_distributed_ray_not_available():
             else importlib.import_module(name)
         ),
     ):
-        executor_class = get_executor_class(distributed=True)
+        executor_class = _get_executor_class(distributed=True)
         assert executor_class == ProcessExecutor


### PR DESCRIPTION
Wrap the `execute_code` tool in a closure so the agent doesn't have to pass the "distributed" flag to the tool.