### PR TITLE
fix: make process executor clean up after itself

### DIFF
--- a/plexe/internal/models/tools/execution.py
+++ b/plexe/internal/models/tools/execution.py
@@ -120,6 +120,7 @@ def get_executor_tool(distributed: bool = False) -> Callable:
                 code_execution_file_name=config.execution.runfile_name,
             )
 
+            # Execute and collect results - ProcessExecutor.run() handles cleanup internally
             logger.debug(f"Executing node {node} using executor {executor}")
             result = executor.run()
             logger.debug(f"Execution result: {result}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plexe"
-version = "0.18.0"
+version = "0.18.1"
 description = "An agentic framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",


### PR DESCRIPTION
This PR ensures `ProcessExecutor` cleans up datasets and other files it writes for model training. No more disk space hogging due to large datasets being copied over and over again!

The PR also slightly simplifies and cleans up the error handling logic in `ProcessExecutor`.