### PR TITLE
fix: improve process executor error handling

### DIFF
--- a/plexe/internal/common/utils/response.py
+++ b/plexe/internal/common/utils/response.py
@@ -100,8 +100,7 @@ def extract_performance(output: str) -> float | None:
 
         # Looking for format "MetricName: value"
         if ":" not in last_line:
-            logger.warning("No colon found in last line")
-            return None
+            raise RuntimeError("No colon found in last line")
 
         value_str = last_line.split(":")[-1].strip()
 
@@ -110,9 +109,7 @@ def extract_performance(output: str) -> float | None:
             logger.debug(f"Successfully parsed value: {value}")
             return value
         except ValueError as e:
-            logger.warning(f"Could not convert '{value_str}' to float: {e}")
-            return None
+            raise RuntimeError(f"Could not convert '{value_str}' to float: {e}") from e
 
     except Exception as e:
-        logger.warning(f"Error extracting performance: {e}")
-        return None
+        raise RuntimeError(f"Error extracting run performance: {e}") from e

--- a/plexe/internal/models/execution/executor.py
+++ b/plexe/internal/models/execution/executor.py
@@ -20,6 +20,14 @@ class ExecutionResult:
     exception: Exception = field(default=None)
     performance: Optional[float] = field(default=None)
 
+    def is_valid_performance(self) -> bool:
+        """Validate if performance metric is usable."""
+        return (
+            self.performance is not None
+            and isinstance(self.performance, (int, float))
+            and self.performance not in [float("inf"), float("-inf")]
+        )
+
 
 class Executor(ABC):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plexe"
-version = "0.18.1"
+version = "0.18.2"
 description = "An agentic framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",

--- a/tests/unit/internal/models/execution/test_process_executor.py
+++ b/tests/unit/internal/models/execution/test_process_executor.py
@@ -54,7 +54,7 @@ class TestProcessExecutor:
     @patch("pyarrow.parquet.write_table")
     def test_run_successful_execution(self, mock_write_table):
         mock_process = MagicMock()
-        mock_process.communicate.return_value = ("Execution completed", "")
+        mock_process.communicate.return_value = ("Performance: 0.5", "")
         mock_process.returncode = 0
 
         with patch("subprocess.Popen", return_value=mock_process) as mock_popen:
@@ -72,8 +72,8 @@ class TestProcessExecutor:
             text=True,
         )
         assert isinstance(result, ExecutionResult)
-        assert "Execution completed" in result.term_out
         assert result.exception is None
+        assert "Performance: 0.5" in result.term_out
 
     @patch("subprocess.Popen")
     def test_run_timeout(self, mock_popen):


### PR DESCRIPTION
This PR makes a number of small improvements to the error handling that wraps ML training code execution:

1. Consolidated logic for detecting invalid or missing performance metric
2. Raise error when performance is missing instead of logging it; it's the LLM that needs to read the error, not the user
3. A few miscellaneous little fixes here and there