### PR TITLE
docs: add bibtext citation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,3 +186,15 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. Join our [Discord](https:
 - [X] Lightweight installation option without heavy deep learning dependencies
 - [X] Distributed training with Ray on AWS
 - [ ] Support for non-tabular data types in model generation
+
+## 8. Citation
+If you use Plexe in your research, please cite it as follows:
+
+```bibtex
+@software{plexe2025,
+  author = {De Bernardi, Marcello AND Dubey, Vaibhav},
+  title = {Plexe: Build machine learning models using natural language.},
+  year = {2025},
+  publisher = {GitHub},
+  howpublished = {\url{https://github.com/plexe-ai/plexe}},
+}


### PR DESCRIPTION
Tiny PR to add a BibTex citation to the README, so that anyone using Plexe in research work can provide correct attribution.