### PR TITLE
feature: conversational interface

### DIFF
--- a/docs/architecture/multi-agent-system.md
+++ b/docs/architecture/multi-agent-system.md
@@ -40,10 +40,12 @@ This approach offers several advantages:
 
 ```mermaid
 graph TD
-    User([User]) --> |"Intent & Datasets"| Model["Model Class"]
+    User([User]) --> |"Intent & Datasets"| ModelBuilder["ModelBuilder"]
+    User --> |"Intent & Datasets"| Model["Model Class (deprecated)"]
     
     subgraph "Multi-Agent System"
-        Model --> |build| Orchestrator["Manager Agent"]
+        ModelBuilder --> |build| Orchestrator["Manager Agent"]
+        Model --> |build (deprecated)| ModelBuilder
         Orchestrator --> |"Schema Task"| SchemaResolver["Schema Resolver"]
         Orchestrator --> |"EDA Task"| EDA["EDA Agent"]
         Orchestrator --> |"Feature Task"| FE["Feature Engineer"]
@@ -191,7 +193,7 @@ self.dataset_splitter_agent = DatasetSplitterAgent(
 
 ### Manager Agent (Orchestrator)
 
-**Class**: `PlexeAgent.manager_agent`  
+**Class**: `CodeAgent`  
 **Type**: `CodeAgent`
 
 The Manager Agent serves as the central coordinator for the entire ML development process:
@@ -339,12 +341,11 @@ class ObjectRegistry:
     """
 
     _instance = None
-    _items: Dict[str, Item] = dict()
 
     def __new__(cls):
         if cls._instance is None:
             cls._instance = super(ObjectRegistry, cls).__new__(cls)
-            cls._items = dict()
+            cls._instance._items = {}
         return cls._instance
 ```
 
@@ -407,12 +408,12 @@ def get_executor_tool(distributed: bool) -> Callable:
 The multi-agent workflow follows these key steps:
 
 1. **Initialization**:
-   - User creates a `Model` instance with intent and datasets
-   - User calls `model.build()` to start the process
+   - User creates a `ModelBuilder` instance or `Model` instance with intent and datasets
+   - User calls `ModelBuilder.build()` or `model.build()` (deprecated) to start the process
 
 2. **Orchestration**:
-   - Manager Agent initializes and coordinates the entire process
-   - Manager Agent tasks specialist agents based on the workflow requirements
+   - `ModelBuilder` (preferred) or `Model.build()` (deprecated) initializes the process
+   - Manager Agent coordinates the entire process and tasks specialist agents based on workflow requirements
 
 3. **Schema Resolution**:
    - If schemas aren't provided, SchemaResolverAgent infers them
@@ -607,19 +608,20 @@ class CustomModelValidator(Validator):
 
 ## References
 
-- [PlexeAgent Class Definition](/plexe/agents/agents.py)
-- [Model Class Definition](/plexe/models.py)
-- [EdaAgent Definition](/plexe/agents/dataset_analyser.py)
-- [SchemaResolverAgent Definition](/plexe/agents/schema_resolver.py)
-- [FeatureEngineeringAgent Definition](/plexe/agents/feature_engineer.py)
-- [DatasetSplitterAgent Definition](/plexe/agents/dataset_splitter.py)
-- [ModelTrainerAgent Definition](/plexe/agents/model_trainer.py)
-- [ModelPackagerAgent Definition](/plexe/agents/model_packager.py)
-- [ModelPlannerAgent Definition](/plexe/agents/model_planner.py)
-- [ModelTesterAgent Definition](/plexe/agents/model_tester.py)
-- [Tool Definitions](/plexe/tools/)
-- [Dataset Tools](/plexe/tools/datasets.py)
-- [Validation Tools](/plexe/tools/validation.py)
-- [Testing Tools](/plexe/tools/testing.py)
-- [Executor Implementation](/plexe/internal/models/execution/)
-- [Object Registry](/plexe/core/object_registry.py)
+- [PlexeAgent Class Definition](plexe/agents/agents.py)
+- [Model Class Definition](plexe/models.py)
+- [ModelBuilder Class Definition](plexe/model_builder.py)
+- [EdaAgent Definition](plexe/agents/dataset_analyser.py)
+- [SchemaResolverAgent Definition](plexe/agents/schema_resolver.py)
+- [FeatureEngineeringAgent Definition](plexe/agents/feature_engineer.py)
+- [DatasetSplitterAgent Definition](plexe/agents/dataset_splitter.py)
+- [ModelTrainerAgent Definition](plexe/agents/model_trainer.py)
+- [ModelPackagerAgent Definition](plexe/agents/model_packager.py)
+- [ModelPlannerAgent Definition](plexe/agents/model_planner.py)
+- [ModelTesterAgent Definition](plexe/agents/model_tester.py)
+- [Tool Definitions](plexe/tools/)
+- [Dataset Tools](plexe/tools/datasets.py)
+- [Validation Tools](plexe/tools/validation.py)
+- [Testing Tools](plexe/tools/testing.py)
+- [Executor Implementation](plexe/internal/models/execution/)
+- [Object Registry](plexe/core/object_registry.py)

--- a/plexe/__init__.py
+++ b/plexe/__init__.py
@@ -1,4 +1,5 @@
 from .models import Model as Model
+from .model_builder import ModelBuilder as ModelBuilder
 from .datasets import DatasetGenerator as DatasetGenerator
 from .fileio import (
     load_model as load_model,

--- a/plexe/agents/conversational.py
+++ b/plexe/agents/conversational.py
@@ -1,0 +1,69 @@
+"""
+Conversational Agent for guiding users through ML model definition and initiation.
+
+This module defines a ConversationalAgent that helps users define their ML requirements
+through natural conversation, validates their inputs, and initiates model building
+when all necessary information has been gathered.
+"""
+
+import logging
+
+from smolagents import ToolCallingAgent, LiteLLMModel
+
+from plexe.internal.common.utils.agents import get_prompt_templates
+from plexe.tools.datasets import get_dataset_preview
+from plexe.tools.conversation import validate_dataset_files, initiate_model_build
+
+logger = logging.getLogger(__name__)
+
+
+class ConversationalAgent:
+    """
+    Agent for conversational model definition and build initiation.
+
+    This agent guides users through defining their ML requirements via natural
+    conversation, helps clarify the problem, validates dataset availability,
+    and initiates the model building process when all requirements are met.
+    """
+
+    def __init__(
+        self,
+        model_id: str = "anthropic/claude-sonnet-4-20250514",
+        verbose: bool = False,
+    ):
+        """
+        Initialize the conversational agent.
+
+        Args:
+            model_id: Model ID for the LLM to use for conversation
+            verbose: Whether to display detailed agent logs
+        """
+        self.model_id = model_id
+        self.verbose = verbose
+
+        # Set verbosity level
+        self.verbosity = 1 if verbose else 0
+
+        # Create the conversational agent with necessary tools
+        self.agent = ToolCallingAgent(
+            name="ModelDefinitionAssistant",
+            description=(
+                "Expert ML consultant that helps users define their machine learning requirements "
+                "through conversational guidance. Specializes in clarifying problem definitions, "
+                "understanding data requirements, and initiating model builds when ready. "
+                "Maintains a friendly, helpful conversation while ensuring all technical "
+                "requirements are properly defined before proceeding with model creation."
+            ),
+            model=LiteLLMModel(model_id=self.model_id),
+            tools=[
+                get_dataset_preview,
+                validate_dataset_files,
+                initiate_model_build,
+            ],
+            add_base_tools=False,
+            verbosity_level=self.verbosity,
+            prompt_templates=get_prompt_templates(
+                base_template_name="toolcalling_agent.yaml",
+                override_template_name="conversational_prompt_templates.yaml",
+            ),
+        )

--- a/plexe/callbacks.py
+++ b/plexe/callbacks.py
@@ -62,9 +62,25 @@ class BuildStateInfo:
     node: Optional[Node] = None
     """The solution node being evaluated in the current iteration."""
 
-    # Reference to the model being built (for callbacks that need direct model access)
-    model: Any = None
-    """Reference to the model being built."""
+    # Model information fields (replacing direct model reference)
+    model_identifier: Optional[str] = None
+    """Model unique identifier."""
+
+    model_state: Optional[str] = None
+    """Current model state (BUILDING/READY/ERROR)."""
+
+    # Final model artifacts (only available at build end)
+    final_metric: Optional[Any] = None
+    """Final performance metric."""
+
+    final_artifacts: Optional[list] = None
+    """Model artifacts list."""
+
+    trainer_source: Optional[str] = None
+    """Training source code."""
+
+    predictor_source: Optional[str] = None
+    """Predictor source code."""
 
 
 class Callback(ABC):

--- a/plexe/core/storage.py
+++ b/plexe/core/storage.py
@@ -81,7 +81,7 @@ def _save_model_to_tar(model: Any, path: str | Path) -> str:
             for key, value in metadata.items():
                 if key in ["metrics", "metadata"]:
                     info = tarfile.TarInfo(f"metadata/{key}.yaml")
-                    content = yaml.dump(value, default_flow_style=False).encode("utf-8")
+                    content = yaml.safe_dump(value, default_flow_style=False).encode("utf-8")
                 else:
                     info = tarfile.TarInfo(f"metadata/{key}.txt")
                     content = str(value).encode("utf-8")
@@ -92,7 +92,7 @@ def _save_model_to_tar(model: Any, path: str | Path) -> str:
             for name, schema in [("input_schema", model.input_schema), ("output_schema", model.output_schema)]:
                 schema_dict = {name: field.annotation.__name__ for name, field in schema.model_fields.items()}
                 info = tarfile.TarInfo(f"schemas/{name}.yaml")
-                content = yaml.dump(schema_dict, default_flow_style=False).encode("utf-8")
+                content = yaml.safe_dump(schema_dict, default_flow_style=False).encode("utf-8")
                 info.size = len(content)
                 tar.addfile(info, io.BytesIO(content))
 
@@ -134,7 +134,7 @@ def _save_model_to_tar(model: Any, path: str | Path) -> str:
             # Save evaluation report if available
             if hasattr(model, "evaluation_report") and model.evaluation_report:
                 info = tarfile.TarInfo("metadata/evaluation_report.yaml")
-                content = yaml.dump(model.evaluation_report, default_flow_style=False).encode("utf-8")
+                content = yaml.safe_dump(model.evaluation_report, default_flow_style=False).encode("utf-8")
                 info.size = len(content)
                 tar.addfile(info, io.BytesIO(content))
 
@@ -340,7 +340,7 @@ def _save_checkpoint_to_tar(model: Any, iteration: int, path: Optional[str | Pat
             for key, value in metadata.items():
                 if key in ["metadata"]:
                     info = tarfile.TarInfo(f"metadata/{key}.yaml")
-                    content = yaml.dump(value, default_flow_style=False).encode("utf-8")
+                    content = yaml.safe_dump(value, default_flow_style=False).encode("utf-8")
                 else:
                     info = tarfile.TarInfo(f"metadata/{key}.txt")
                     content = str(value).encode("utf-8")
@@ -351,7 +351,7 @@ def _save_checkpoint_to_tar(model: Any, iteration: int, path: Optional[str | Pat
             for name, schema in [("input_schema", model.input_schema), ("output_schema", model.output_schema)]:
                 schema_dict = {name: field.annotation.__name__ for name, field in schema.model_fields.items()}
                 info = tarfile.TarInfo(f"schemas/{name}.yaml")
-                content = yaml.dump(schema_dict, default_flow_style=False).encode("utf-8")
+                content = yaml.safe_dump(schema_dict, default_flow_style=False).encode("utf-8")
                 info.size = len(content)
                 tar.addfile(info, io.BytesIO(content))
 

--- a/plexe/main.py
+++ b/plexe/main.py
@@ -2,11 +2,13 @@
 Application entry point for using the plexe package as a conversational agent.
 """
 
-# TODO: launch chat UI from here
+from smolagents import GradioUI
+from plexe.agents.conversational import ConversationalAgent
 
 
 def main():
-    pass
+    ui = GradioUI(ConversationalAgent().agent)
+    ui.launch()
 
 
 if __name__ == "__main__":

--- a/plexe/model_builder.py
+++ b/plexe/model_builder.py
@@ -131,8 +131,20 @@ class ModelBuilder:
             if output_schema:
                 object_registry.register(dict, "output_schema", format_schema(output_schema), immutable=True)
 
+            # Generate unique model identifier
+            model_identifier = f"model-{datetime.now().isoformat()}".replace(":", "-").replace(".", "-")
+
             # Notify callbacks of build start
-            self._notify_callbacks(callbacks, "build_start", intent, input_schema, output_schema, training_data)
+            self._notify_callbacks(
+                callbacks,
+                "build_start",
+                intent,
+                input_schema,
+                output_schema,
+                training_data,
+                model_identifier=model_identifier,
+                model_state="BUILDING",
+            )
 
             # Create and run agent
             agent = PlexeAgent(
@@ -203,6 +215,7 @@ class ModelBuilder:
 
             # Create model and populate it with results
             model = Model(intent=intent, input_schema=final_input_schema, output_schema=final_output_schema)
+            model.identifier = model_identifier
             model.predictor = generated.predictor
             model.trainer_source = generated.training_source_code
             model.predictor_source = generated.inference_source_code
@@ -218,7 +231,18 @@ class ModelBuilder:
 
             # Notify callbacks of build end
             self._notify_callbacks(
-                callbacks, "build_end", intent, final_input_schema, final_output_schema, training_data, model
+                callbacks,
+                "build_end",
+                intent,
+                final_input_schema,
+                final_output_schema,
+                training_data,
+                model_identifier=model_identifier,
+                model_state="READY",
+                final_metric=generated.test_performance,
+                final_artifacts=generated.model_artifacts,
+                trainer_source=generated.training_source_code,
+                predictor_source=generated.inference_source_code,
             )
 
             return model
@@ -227,7 +251,21 @@ class ModelBuilder:
             logger.error(f"Error during model building: {str(e)}")
             raise e
 
-    def _notify_callbacks(self, callbacks, event, intent, input_schema, output_schema, training_data, model=None):
+    def _notify_callbacks(
+        self,
+        callbacks,
+        event,
+        intent,
+        input_schema,
+        output_schema,
+        training_data,
+        model_identifier=None,
+        model_state=None,
+        final_metric=None,
+        final_artifacts=None,
+        trainer_source=None,
+        predictor_source=None,
+    ):
         """Helper to notify callbacks with consistent error handling."""
         for callback in callbacks:
             try:
@@ -240,7 +278,12 @@ class ModelBuilder:
                             output_schema=output_schema,
                             provider=self.provider_config.tool_provider,
                             datasets=training_data,
-                            model=model,
+                            model_identifier=model_identifier,
+                            model_state=model_state,
+                            final_metric=final_metric,
+                            final_artifacts=final_artifacts,
+                            trainer_source=trainer_source,
+                            predictor_source=predictor_source,
                         )
                     )
             except Exception as e:

--- a/plexe/model_builder.py
+++ b/plexe/model_builder.py
@@ -1,0 +1,247 @@
+"""
+ModelBuilder for creating ML models through agentic workflows.
+
+This module provides the ModelBuilder class that handles the orchestration of 
+the multi-agent system to build machine learning models.
+"""
+
+import os
+import json
+import logging
+from datetime import datetime
+from typing import Dict, List, Type, Optional
+
+import pandas as pd
+from pydantic import BaseModel
+
+from plexe.config import prompt_templates
+from plexe.datasets import DatasetGenerator
+from plexe.callbacks import Callback, BuildStateInfo, ChainOfThoughtModelCallback, ModelCheckpointCallback
+from plexe.internal.common.utils.chain_of_thought.emitters import ConsoleEmitter
+from plexe.agents.agents import PlexeAgent
+from plexe.internal.common.datasets.interface import TabularConvertible
+from plexe.internal.common.datasets.adapter import DatasetAdapter
+from plexe.internal.common.provider import ProviderConfig
+from plexe.core.object_registry import ObjectRegistry
+from plexe.internal.common.utils.pydantic_utils import map_to_basemodel, format_schema
+from plexe.internal.common.utils.markdown_utils import format_eda_report_markdown
+from plexe.core.state import ModelState
+
+logger = logging.getLogger(__name__)
+
+
+class ModelBuilder:
+    """Factory for creating ML models through agentic workflows."""
+
+    def __init__(
+        self,
+        provider: str | ProviderConfig = "openai/gpt-4o-mini",
+        verbose: bool = False,
+        distributed: bool = False,
+        working_dir: Optional[str] = None,
+    ):
+        """
+        Initialize the model builder.
+
+        Args:
+            provider: LLM provider configuration
+            verbose: Whether to display detailed agent logs
+            distributed: Whether to use distributed training with Ray
+            working_dir: Optional custom working directory
+        """
+        self.provider_config = ProviderConfig(default_provider=provider) if isinstance(provider, str) else provider
+        self.verbose = verbose
+        self.distributed = distributed
+        self.working_dir = working_dir or self._create_working_dir()
+
+    @staticmethod
+    def _create_working_dir() -> str:
+        """Create unique working directory for this build."""
+        run_id = f"run-{datetime.now().isoformat()}".replace(":", "-").replace(".", "-")
+        working_dir = f"./workdir/{run_id}/"
+        os.makedirs(working_dir, exist_ok=True)
+        return working_dir
+
+    def build(
+        self,
+        intent: str,
+        datasets: List[pd.DataFrame | DatasetGenerator],
+        input_schema: Type[BaseModel] | Dict[str, type] = None,
+        output_schema: Type[BaseModel] | Dict[str, type] = None,
+        timeout: int = None,
+        max_iterations: int = None,
+        run_timeout: int = 1800,
+        callbacks: List[Callback] = None,
+        enable_checkpointing: bool = False,
+    ):
+        """
+        Build a complete ML model using the agentic workflow.
+
+        Args:
+            intent: Natural language description of the model's purpose
+            datasets: Training datasets
+            input_schema: Optional input schema (inferred if not provided)
+            output_schema: Optional output schema (inferred if not provided)
+            timeout: Maximum total time for building
+            max_iterations: Maximum number of iterations
+            run_timeout: Maximum time per training run
+            callbacks: Optional callbacks for monitoring
+            enable_checkpointing: Whether to enable checkpointing
+
+        Returns:
+            Completed Model instance
+        """
+        # Clear and use singleton object registry for this build
+        object_registry = ObjectRegistry()
+        object_registry.clear()
+
+        # Validate parameters
+        if timeout is None and max_iterations is None:
+            raise ValueError("At least one of 'timeout' or 'max_iterations' must be set")
+        if run_timeout is not None and timeout is not None and run_timeout > timeout:
+            raise ValueError(f"Run timeout ({run_timeout}s) cannot exceed total timeout ({timeout}s)")
+
+        # Process schemas
+        input_schema = map_to_basemodel("in", input_schema) if input_schema else None
+        output_schema = map_to_basemodel("out", output_schema) if output_schema else None
+
+        # Initialize callbacks
+        callbacks = callbacks or []
+        if enable_checkpointing and not any(isinstance(cb, ModelCheckpointCallback) for cb in callbacks):
+            callbacks.append(ModelCheckpointCallback())
+
+        cot_callback = ChainOfThoughtModelCallback(emitter=ConsoleEmitter())
+        callbacks.append(cot_callback)
+        cot_callable = cot_callback.get_chain_of_thought_callable()
+
+        # Register callbacks
+        object_registry.register_multiple(Callback, {f"{i}": c for i, c in enumerate(callbacks)})
+
+        try:
+            # Register datasets
+            training_data = {
+                f"dataset_{i}": DatasetAdapter.coerce((data.data if isinstance(data, DatasetGenerator) else data))
+                for i, data in enumerate(datasets)
+            }
+            object_registry.register_multiple(TabularConvertible, training_data, immutable=True)
+
+            # Register schemas if provided
+            if input_schema:
+                object_registry.register(dict, "input_schema", format_schema(input_schema), immutable=True)
+            if output_schema:
+                object_registry.register(dict, "output_schema", format_schema(output_schema), immutable=True)
+
+            # Notify callbacks of build start
+            self._notify_callbacks(callbacks, "build_start", intent, input_schema, output_schema, training_data)
+
+            # Create and run agent
+            agent = PlexeAgent(
+                orchestrator_model_id=self.provider_config.orchestrator_provider,
+                ml_researcher_model_id=self.provider_config.research_provider,
+                ml_engineer_model_id=self.provider_config.engineer_provider,
+                ml_ops_engineer_model_id=self.provider_config.ops_provider,
+                tool_model_id=self.provider_config.tool_provider,
+                verbose=self.verbose,
+                max_steps=30,
+                distributed=self.distributed,
+                chain_of_thought_callable=cot_callable,
+            )
+
+            agent_prompt = prompt_templates.agent_builder_prompt(
+                intent=intent,
+                input_schema=json.dumps(format_schema(input_schema), indent=4),
+                output_schema=json.dumps(format_schema(output_schema), indent=4),
+                datasets=list(training_data.keys()),
+                working_dir=self.working_dir,
+                max_iterations=max_iterations,
+                resume=False,
+            )
+
+            additional_args = {
+                "intent": intent,
+                "working_dir": self.working_dir,
+                "input_schema": format_schema(input_schema),
+                "output_schema": format_schema(output_schema),
+                "max_iterations": max_iterations,
+                "timeout": timeout,
+                "run_timeout": run_timeout,
+            }
+
+            generated = agent.run(agent_prompt, additional_args=additional_args)
+
+            # Extract final schemas (may have been inferred)
+            final_input_schema = map_to_basemodel("InputSchema", object_registry.get(dict, "input_schema"))
+            final_output_schema = map_to_basemodel("OutputSchema", object_registry.get(dict, "output_schema"))
+
+            # Build metadata
+            metadata = {
+                "provider": str(self.provider_config.default_provider),
+                "orchestrator_provider": str(self.provider_config.orchestrator_provider),
+                "research_provider": str(self.provider_config.research_provider),
+                "engineer_provider": str(self.provider_config.engineer_provider),
+                "ops_provider": str(self.provider_config.ops_provider),
+                "tool_provider": str(self.provider_config.tool_provider),
+            }
+            metadata.update(generated.metadata)
+
+            # Extract EDA reports
+            eda_reports = {}
+            eda_markdown_reports = {}
+            for name in training_data.keys():
+                try:
+                    eda_report = object_registry.get(dict, f"eda_report_{name}")
+                    eda_reports[name] = eda_report
+                    eda_markdown_reports[name] = format_eda_report_markdown(eda_report)
+                except KeyError:
+                    logger.debug(f"No EDA report found for dataset '{name}'")
+
+            metadata["eda_reports"] = eda_reports
+            metadata["eda_markdown_reports"] = eda_markdown_reports
+
+            # Import here to avoid circular dependency
+            from plexe.models import Model
+
+            # Create model and populate it with results
+            model = Model(intent=intent, input_schema=final_input_schema, output_schema=final_output_schema)
+            model.predictor = generated.predictor
+            model.trainer_source = generated.training_source_code
+            model.predictor_source = generated.inference_source_code
+            model.feature_transformer_source = generated.feature_transformer_source_code
+            model.dataset_splitter_source = generated.dataset_split_code
+            model.testing_source = generated.testing_source_code
+            model.artifacts = generated.model_artifacts
+            model.metric = generated.test_performance
+            model.evaluation_report = generated.evaluation_report
+            model.metadata.update(metadata)
+            model.training_data = training_data  # Store actual training data
+            model.state = ModelState.READY
+
+            # Notify callbacks of build end
+            self._notify_callbacks(
+                callbacks, "build_end", intent, final_input_schema, final_output_schema, training_data, model
+            )
+
+            return model
+
+        except Exception as e:
+            logger.error(f"Error during model building: {str(e)}")
+            raise e
+
+    def _notify_callbacks(self, callbacks, event, intent, input_schema, output_schema, training_data, model=None):
+        """Helper to notify callbacks with consistent error handling."""
+        for callback in callbacks:
+            try:
+                method_name = f"on_{event}"
+                if hasattr(callback, method_name):
+                    getattr(callback, method_name)(
+                        BuildStateInfo(
+                            intent=intent,
+                            input_schema=input_schema,
+                            output_schema=output_schema,
+                            provider=self.provider_config.tool_provider,
+                            datasets=training_data,
+                            model=model,
+                        )
+                    )
+            except Exception as e:
+                logger.warning(f"Error in callback {callback.__class__.__name__}.{method_name}: {str(e)[:50]}")

--- a/plexe/models.py
+++ b/plexe/models.py
@@ -33,29 +33,26 @@ Example:
 >>>    print(prediction)
 """
 
-import os
-import json
 import logging
+import os
 import uuid
-from typing import Dict, List, Type, Any
+import warnings
 from datetime import datetime
+from typing import Dict, List, Type, Any
+from deprecated import deprecated
 
 import pandas as pd
 from pydantic import BaseModel
 
-from plexe.config import prompt_templates
-from plexe.datasets import DatasetGenerator
-from plexe.callbacks import Callback, BuildStateInfo, ChainOfThoughtModelCallback, ModelCheckpointCallback
-from plexe.internal.common.utils.chain_of_thought.emitters import ConsoleEmitter
-from plexe.agents.agents import PlexeAgent
-from plexe.internal.common.datasets.interface import Dataset, TabularConvertible
-from plexe.internal.common.datasets.adapter import DatasetAdapter
-from plexe.internal.common.provider import ProviderConfig
+from plexe.callbacks import Callback
+from plexe.core.interfaces.predictor import Predictor
 from plexe.core.object_registry import ObjectRegistry
+from plexe.core.state import ModelState  # Import from core package
+from plexe.datasets import DatasetGenerator
+from plexe.internal.common.datasets.interface import Dataset
+from plexe.internal.common.provider import ProviderConfig
 from plexe.internal.common.utils.model_utils import calculate_model_size, format_code_snippet
 from plexe.internal.common.utils.pydantic_utils import map_to_basemodel, format_schema
-from plexe.core.state import ModelState  # Import from core package
-from plexe.internal.common.utils.markdown_utils import format_eda_report_markdown
 from plexe.internal.models.entities.artifact import Artifact
 from plexe.internal.models.entities.description import (
     ModelDescription,
@@ -65,7 +62,6 @@ from plexe.internal.models.entities.description import (
     CodeInfo,
 )
 from plexe.internal.models.entities.metric import Metric
-from plexe.core.interfaces.predictor import Predictor
 
 logger = logging.getLogger(__name__)
 
@@ -141,6 +137,7 @@ class Model:
         self.working_dir = f"./workdir/{self.run_id}/"
         os.makedirs(self.working_dir, exist_ok=True)
 
+    @deprecated(reason="Use ModelBuilder.build() instead", version="0.23.0")
     def build(
         self,
         datasets: List[pd.DataFrame | DatasetGenerator],
@@ -156,6 +153,12 @@ class Model:
         """
         Build the model using the provided dataset and optional data generation configuration.
 
+        DEPRECATED: This interface is deprecated. Use ModelBuilder.build() instead:
+
+            from plexe import ModelBuilder
+            builder = ModelBuilder(provider=provider, verbose=verbose, distributed=distributed)
+            model = builder.build(intent=intent, datasets=datasets, ...)
+
         :param datasets: the datasets to use for training the model
         :param provider: the provider to use for model building, either a string or a ProviderConfig
                          for granular control of which models to use for different agent roles
@@ -167,210 +170,58 @@ class Model:
         :param enable_checkpointing: whether to enable automatic checkpointing (default: True)
         :return:
         """
-        # Ensure the object registry is cleared before building
-        self.object_registry.clear()
+        warnings.warn(
+            "Model.build() is deprecated. Use ModelBuilder.build() instead:\n\n"
+            "    from plexe import ModelBuilder\n"
+            "    builder = ModelBuilder(provider=provider, verbose=verbose, distributed=distributed)\n"
+            "    model = builder.build(intent=intent, datasets=datasets, ...)\n",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
-        # Initialize callbacks list if not provided
-        callbacks = callbacks or []
+        # Import here to avoid circular dependency
+        from plexe.model_builder import ModelBuilder
 
-        # Add automatic checkpointing callback if enabled
-        if enable_checkpointing and not any(isinstance(cb, ModelCheckpointCallback) for cb in callbacks):
-            callbacks.append(ModelCheckpointCallback())
+        # Create builder and delegate to it
+        builder = ModelBuilder(
+            provider=provider,
+            verbose=verbose,
+            distributed=self.distributed,
+            working_dir=self.working_dir,
+        )
 
-        # Add chain of thought callback
-        cot_model_callback = ChainOfThoughtModelCallback(emitter=ConsoleEmitter())
-        callbacks.append(cot_model_callback)
+        # Build the model using ModelBuilder
+        built_model = builder.build(
+            intent=self.intent,
+            datasets=datasets,
+            input_schema=self.input_schema,
+            output_schema=self.output_schema,
+            timeout=timeout,
+            max_iterations=max_iterations,
+            run_timeout=run_timeout,
+            callbacks=callbacks,
+            enable_checkpointing=enable_checkpointing,
+        )
 
-        # Get the underlying callable for use with agents
-        cot_callable = cot_model_callback.get_chain_of_thought_callable()
+        # Copy all results back to self to maintain backwards compatibility
+        for attr in [
+            "input_schema",
+            "output_schema",
+            "predictor",
+            "trainer_source",
+            "predictor_source",
+            "feature_transformer_source",
+            "dataset_splitter_source",
+            "testing_source",
+            "evaluation_report",
+            "artifacts",
+            "metric",
+            "training_data",
+        ]:
+            setattr(self, attr, getattr(built_model, attr))
 
-        # Register all callbacks in the object registry
-        self.object_registry.register_multiple(Callback, {f"{i}": c for i, c in enumerate(callbacks)})
-
-        # Ensure timeout, max_iterations, and run_timeout make sense
-        if timeout is None and max_iterations is None:
-            raise ValueError("At least one of 'timeout' or 'max_iterations' must be set")
-        if run_timeout is not None and timeout is not None and run_timeout > timeout:
-            raise ValueError(f"Run timeout ({run_timeout}s) cannot exceed total timeout ({timeout}s)")
-
-        try:
-            # Convert string provider to config if needed
-            if isinstance(provider, str):
-                provider_config = ProviderConfig(default_provider=provider)
-            else:
-                provider_config = provider
-
-            # We use the tool_provider for schema resolution and tool operations
-            self.state = ModelState.BUILDING
-
-            # Step 1: coerce datasets to supported formats and register them
-            self.training_data = {
-                f"dataset_{i}": DatasetAdapter.coerce((data.data if isinstance(data, DatasetGenerator) else data))
-                for i, data in enumerate(datasets)
-            }
-            self.object_registry.register_multiple(TabularConvertible, self.training_data, immutable=True)
-
-            # Step 2: register input schemas into object registry, if they are provided
-            if self.input_schema is not None:
-                self.object_registry.register(dict, "input_schema", format_schema(self.input_schema), immutable=True)
-            if self.output_schema is not None:
-                self.object_registry.register(dict, "output_schema", format_schema(self.output_schema), immutable=True)
-
-            # Run callbacks for build start
-            for callback in self.object_registry.get_all(Callback).values():
-                try:
-                    # Note: callbacks still receive the actual dataset objects for backward compatibility
-                    callback.on_build_start(
-                        BuildStateInfo(
-                            intent=self.intent,
-                            input_schema=self.input_schema,
-                            output_schema=self.output_schema,
-                            provider=provider_config.tool_provider,  # Use tool_provider for callbacks
-                            run_timeout=run_timeout,
-                            max_iterations=max_iterations,
-                            timeout=timeout,
-                            datasets={
-                                name: self.object_registry.get(TabularConvertible, name)
-                                for name in self.training_data.keys()
-                            },
-                            model=self,  # Include reference to model for checkpoint callback
-                        )
-                    )
-                except Exception as e:
-                    # Log full stack trace at debug level
-                    import traceback
-
-                    logger.debug(
-                        f"Error in callback {callback.__class__.__name__}.on_build_start: {e}\n{traceback.format_exc()}"
-                    )
-
-                    # Log a shorter message at warning level
-                    logger.warning(f"Error in callback {callback.__class__.__name__}.on_build_start: {str(e)[:50]}")
-
-            # Step 4: generate model
-            agent_prompt = prompt_templates.agent_builder_prompt(
-                intent=self.intent,
-                input_schema=json.dumps(format_schema(self.input_schema), indent=4),
-                output_schema=json.dumps(format_schema(self.output_schema), indent=4),
-                datasets=list(self.training_data.keys()),
-                working_dir=self.working_dir,
-                max_iterations=max_iterations,
-                resume=False,
-            )
-
-            agent = PlexeAgent(
-                orchestrator_model_id=provider_config.orchestrator_provider,
-                ml_researcher_model_id=provider_config.research_provider,
-                ml_engineer_model_id=provider_config.engineer_provider,
-                ml_ops_engineer_model_id=provider_config.ops_provider,
-                tool_model_id=provider_config.tool_provider,
-                verbose=verbose,
-                max_steps=30,
-                distributed=self.distributed,
-                chain_of_thought_callable=cot_callable,
-            )
-
-            # Prepare agent args
-            additional_args = {
-                "intent": self.intent,
-                "working_dir": self.working_dir,
-                "input_schema": format_schema(self.input_schema),
-                "output_schema": format_schema(self.output_schema),
-                "max_iterations": max_iterations,
-                "timeout": timeout,
-                "run_timeout": run_timeout,
-            }
-
-            generated = agent.run(agent_prompt, additional_args=additional_args)
-
-            # Capture inferred schemas
-            self.input_schema = map_to_basemodel("InputSchema", self.object_registry.get(dict, "input_schema"))
-            self.output_schema = map_to_basemodel("OutputSchema", self.object_registry.get(dict, "output_schema"))
-
-            # Run callbacks for build end
-            for callback in self.object_registry.get_all(Callback).values():
-                try:
-                    # Note: callbacks still receive the actual dataset objects for backward compatibility
-                    callback.on_build_end(
-                        BuildStateInfo(
-                            intent=self.intent,
-                            input_schema=self.input_schema,
-                            output_schema=self.output_schema,
-                            provider=provider,
-                            run_timeout=run_timeout,
-                            max_iterations=max_iterations,
-                            timeout=timeout,
-                            datasets={
-                                name: self.object_registry.get(TabularConvertible, name)
-                                for name in self.training_data.keys()
-                            },
-                            model=self,  # Include reference to model for checkpoint callback
-                        )
-                    )
-                except Exception as e:
-                    # Log full stack trace at debug level
-                    import traceback
-
-                    logger.debug(
-                        f"Error in callback {callback.__class__.__name__}.on_build_end: {e}\n{traceback.format_exc()}"
-                    )
-
-                    # Log a shorter message at warning level
-                    logger.warning(f"Error in callback {callback.__class__.__name__}.on_build_end: {str(e)[:50]}")
-
-            # Step 4: update model state and attributes
-            self.trainer_source = generated.training_source_code
-            self.predictor_source = generated.inference_source_code
-            self.feature_transformer_source = generated.feature_transformer_source_code
-            self.dataset_splitter_source = generated.dataset_split_code
-            self.testing_source = generated.testing_source_code
-            self.evaluation_report = generated.evaluation_report
-            self.predictor = generated.predictor
-            self.artifacts = generated.model_artifacts
-
-            # Convert Metric object to a dictionary with the entire metric object as the value
-            self.metric = generated.test_performance
-
-            # Store the model metadata from the generation process
-            self.metadata.update(generated.metadata)
-
-            # Store provider information in metadata
-            self.metadata["provider"] = str(provider_config.default_provider)
-            self.metadata["orchestrator_provider"] = str(provider_config.orchestrator_provider)
-            self.metadata["research_provider"] = str(provider_config.research_provider)
-            self.metadata["engineer_provider"] = str(provider_config.engineer_provider)
-            self.metadata["ops_provider"] = str(provider_config.ops_provider)
-            self.metadata["tool_provider"] = str(provider_config.tool_provider)
-
-            # Store EDA results in metadata
-            eda_reports = {}
-            eda_markdown_reports = {}
-            for name, dataset in self.training_data.items():
-                try:
-                    eda_report = self.object_registry.get(dict, f"eda_report_{name}")
-                    eda_reports[name] = eda_report
-                    # Generate markdown version of the report
-                    eda_markdown = format_eda_report_markdown(eda_report)
-                    eda_markdown_reports[name] = eda_markdown
-                except KeyError:
-                    logger.debug(f"No EDA report found for dataset '{name}'")
-
-            # Store both raw and markdown versions in metadata
-            self.metadata["eda_reports"] = eda_reports
-            self.metadata["eda_markdown_reports"] = eda_markdown_reports
-
-            self.state = ModelState.READY
-
-        except Exception as e:
-            self.state = ModelState.ERROR
-            # Log full stack trace at debug level
-            import traceback
-
-            logger.debug(f"Error during model building: {str(e)}\n{traceback.format_exc()}")
-
-            # Log a shorter message at error level
-            logger.error(f"Error during model building: {str(e)[:50]}")
-            raise e
+        self.metadata.update(built_model.metadata)
+        self.state = ModelState.READY
 
     def predict(self, x: Dict[str, Any], validate_input: bool = False, validate_output: bool = False) -> Dict[str, Any]:
         """

--- a/plexe/models.py
+++ b/plexe/models.py
@@ -205,6 +205,7 @@ class Model:
 
         # Copy all results back to self to maintain backwards compatibility
         for attr in [
+            "identifier",
             "input_schema",
             "output_schema",
             "predictor",

--- a/plexe/templates/prompts/agent/conversational_prompt_templates.yaml
+++ b/plexe/templates/prompts/agent/conversational_prompt_templates.yaml
@@ -1,0 +1,152 @@
+system_prompt: |-
+  You are an expert assistant who can solve any task using tool calls. You will be given a task to solve as best you can.
+  To do so, you have been given access to some tools.
+
+  The tool call you write is an action: after the tool is executed, you will get the result of the tool call as an "observation".
+  This Action/Observation can repeat N times, you should take several steps when needed.
+
+  You can use the result of the previous action as input for the next action.
+  The observation will always be a string: it can represent a file, like "image_1.jpg".
+  Then you can use it as input for the next action. You can do it for instance as follows:
+
+  Observation: "image_1.jpg"
+
+  Action:
+  {
+    "name": "image_transformer",
+    "arguments": {"image": "image_1.jpg"}
+  }
+
+  To provide the final answer to the task, use an action blob with "name": "final_answer" tool. It is the only way to complete the task, else you will be stuck on a loop. So your final output should look like this:
+  Action:
+  {
+    "name": "final_answer",
+    "arguments": {"answer": "insert your final answer here"}
+  }
+
+
+  Here are a few examples using notional tools:
+  ---
+  Task: "Generate an image of the oldest person in this document."
+
+  Action:
+  {
+    "name": "document_qa",
+    "arguments": {"document": "document.pdf", "question": "Who is the oldest person mentioned?"}
+  }
+  Observation: "The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland."
+
+  Action:
+  {
+    "name": "image_generator",
+    "arguments": {"prompt": "A portrait of John Doe, a 55-year-old man living in Canada."}
+  }
+  Observation: "image.png"
+
+  Action:
+  {
+    "name": "final_answer",
+    "arguments": "image.png"
+  }
+
+  ---
+  Task: "What is the result of the following operation: 5 + 3 + 1294.678?"
+
+  Action:
+  {
+      "name": "python_interpreter",
+      "arguments": {"code": "5 + 3 + 1294.678"}
+  }
+  Observation: 1302.678
+
+  Action:
+  {
+    "name": "final_answer",
+    "arguments": "1302.678"
+  }
+
+  ---
+  Task: "Which city has the highest population , Guangzhou or Shanghai?"
+
+  Action:
+  {
+      "name": "search",
+      "arguments": "Population Guangzhou"
+  }
+  Observation: ['Guangzhou has a population of 15 million inhabitants as of 2021.']
+
+
+  Action:
+  {
+      "name": "search",
+      "arguments": "Population Shanghai"
+  }
+  Observation: '26 million (2019)'
+
+  Action:
+  {
+    "name": "final_answer",
+    "arguments": "Shanghai"
+  }
+
+  Above example were using notional tools that might not exist for you. You only have access to these tools:
+  {%- for tool in tools.values() %}
+  - {{ tool.name }}: {{ tool.description }}
+      Takes inputs: {{tool.inputs}}
+      Returns an output of type: {{tool.output_type}}
+  {%- endfor %}
+
+  {%- if managed_agents and managed_agents.values() | list %}
+  You can also give tasks to team members.
+  Calling a team member works the same as for calling a tool: simply, the only argument you can give in the call is 'task', a long string explaining your task.
+  Given that this team member is a real human, you should be very verbose in your task.
+  Here is a list of the team members that you can call:
+  {%- for agent in managed_agents.values() %}
+  - {{ agent.name }}: {{ agent.description }}
+  {%- endfor %}
+  {%- endif %}
+
+  Here are the rules you should always follow to solve your task:
+  1. ALWAYS provide a tool call, else you will fail.
+  2. Always use the right arguments for the tools. Never use variable names as the action arguments, use the value instead.
+  3. Call a tool only when needed: do not call the search agent if you do not need information, try to solve the task yourself.
+  If no tool call is needed, use final_answer tool to return your answer.
+  4. Never re-do a tool call that you previously did with the exact same parameters.
+
+  Now Begin!
+
+
+  ## CRITICAL: ML Model Definition Assistant
+
+  **PRIMARY ROLE**: Guide users through ML model definition via conversation. DO NOT rush to build models.
+
+  ### MANDATORY REQUIREMENTS BEFORE USING initiate_model_build:
+  1. **Clear Problem Statement**: User has articulated EXACTLY what they want to predict/classify
+  2. **Input/Output Definition**: Clear understanding of model inputs and expected outputs  
+  3. **Data Understanding**: You have examined their data using get_dataset_preview
+  4. **Build Parameters**: You have asked the user for the optional build parameters (model schemas, n solutions to try,
+     etc). The user can skip these ('I don't know', 'you decide', etc.) but you must ask
+  5. **Explicit User Confirmation**: User explicitly says they are ready to start building
+
+  ### YOUR CONVERSATION STRATEGY:
+  - Ask ONE focused question at a time
+  - Use get_dataset_preview to understand their data BEFORE asking detailed questions
+  - Ask follow-up questions based on what you see in their data
+  - Help them refine vague statements into precise ML problem definitions
+  - Summarize their requirements and ask for confirmation before proceeding
+  - Be conversational and friendly, not formal or robotic
+  - Provide examples when helpful (e.g., "Predict house prices based on location, size, and features")
+
+  ### WHEN TO USE TOOLS:
+  - `validate_dataset_files`: First step after getting file paths
+  - `get_dataset_preview`: Essential for understanding their data structure
+  - `initiate_model_build`: ONLY after completing ALL requirements above
+
+  ### EXAMPLES OF INSUFFICIENT vs SUFFICIENT PROBLEM DEFINITIONS:
+  **INSUFFICIENT**: "Predict sales" 
+  **SUFFICIENT**: "Predict monthly sales revenue for each product category based on historical sales data, seasonal patterns, and marketing spend"
+
+  **INSUFFICIENT**: "Classify customers"
+  **SUFFICIENT**: "Classify customers as high-risk/low-risk for loan default based on credit history, income, and demographic data"
+
+  **REMEMBER**: Your job is requirements gathering, not model building. The clearer the requirements, the better the final model.

--- a/plexe/tools/conversation.py
+++ b/plexe/tools/conversation.py
@@ -1,0 +1,163 @@
+"""
+Tools for conversational model definition and build initiation.
+
+These tools support the conversational agent in helping users define their ML
+requirements and starting model builds when ready.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pandas as pd
+from smolagents import tool
+
+import plexe
+from plexe.internal.common.datasets.adapter import DatasetAdapter
+from plexe.internal.common.datasets.interface import TabularConvertible
+from plexe.internal.common.provider import ProviderConfig
+from plexe.core.object_registry import ObjectRegistry
+
+logger = logging.getLogger(__name__)
+
+
+@tool
+def validate_dataset_files(file_paths: List[str]) -> Dict[str, Dict]:
+    """
+    Check if specified file paths can be read as datasets using pandas.
+
+    Args:
+        file_paths: List of file paths to validate
+
+    Returns:
+        Dictionary mapping file paths to validation results with status, shape, and error info
+    """
+    results = {}
+
+    for file_path in file_paths:
+        result = {"valid": False, "shape": None, "columns": None, "error": None}
+
+        try:
+            # Check if file exists
+            if not os.path.exists(file_path):
+                result["error"] = f"File does not exist: {file_path}"
+                results[file_path] = result
+                continue
+
+            # Determine file type and try to read
+            path_obj = Path(file_path)
+            file_extension = path_obj.suffix.lower()
+
+            if file_extension == ".csv":
+                df = pd.read_csv(file_path)
+            elif file_extension in [".parquet", ".pq"]:
+                df = pd.read_parquet(file_path)
+            else:
+                result["error"] = f"Unsupported file format: {file_extension}. Supported formats: .csv, .parquet"
+                results[file_path] = result
+                continue
+
+            # File successfully read
+            result["valid"] = True
+            result["dataset_name"] = path_obj.stem
+
+            # Register the DataFrame in object registry
+            ObjectRegistry().register(
+                t=TabularConvertible, name=path_obj.stem, item=DatasetAdapter.coerce(df), immutable=True
+            )
+
+        except Exception as e:
+            result["error"] = str(e)
+
+        results[file_path] = result
+
+    return results
+
+
+@tool
+def initiate_model_build(
+    intent: str,
+    dataset_file_paths: List[str],
+    input_schema: Optional[Dict] = None,
+    output_schema: Optional[Dict] = None,
+    n_solutions_to_try: int = 1,
+) -> Dict[str, str]:
+    """
+    Initiate a model build by loading datasets from file paths and starting the build process.
+
+    Args:
+        intent: Natural language description of what the model should do
+        dataset_file_paths: List of file paths to dataset files (CSV or Parquet)
+        input_schema: The input schema for the model, as a flat field:type dictionary; leave None if not known
+        output_schema: The output schema for the model, as a flat field:type dictionary; leave None if not known
+        n_solutions_to_try: Number of model solutions to try, out of which the best will be selected
+
+    Returns:
+        Dictionary with build initiation status and details
+    """
+    try:
+        # First validate all files can be read
+        validation_results = validate_dataset_files(dataset_file_paths)
+
+        # Check if any files failed validation
+        failed_files = [path for path, result in validation_results.items() if not result["valid"]]
+        if failed_files:
+            error_details = {path: validation_results[path]["error"] for path in failed_files}
+            return {
+                "status": "failed",
+                "message": f"Failed to read dataset files: {failed_files}",
+                "errors": error_details,
+            }
+
+        # Load datasets into DataFrames
+        df = None
+        for file_path in dataset_file_paths:
+            path_obj = Path(file_path)
+            file_extension = path_obj.suffix.lower()
+
+            if file_extension == ".csv":
+                df = pd.read_csv(file_path)
+            elif file_extension in [".parquet", ".pq"]:
+                df = pd.read_parquet(file_path)
+
+        # Import here to avoid circular dependencies
+        from plexe.model_builder import ModelBuilder
+
+        # Create ModelBuilder instance with loaded DataFrames
+        model_builder = ModelBuilder(
+            provider=ProviderConfig(
+                default_provider="openai/gpt-4o",
+                orchestrator_provider="anthropic/claude-3-7-sonnet-20250219",
+                research_provider="openai/gpt-4o",
+                engineer_provider="anthropic/claude-sonnet-4-20250514",
+                ops_provider="anthropic/claude-sonnet-4-20250514",
+                tool_provider="openai/gpt-4o",
+            ),
+        )
+
+        # Start the build process
+        logger.info(f"Initiating model build with intent: {intent}")
+        logger.info(f"Using dataset files: {dataset_file_paths}")
+
+        model = model_builder.build(
+            intent=intent,
+            datasets=[df],  # Pass actual DataFrames instead of names
+            input_schema=input_schema,
+            output_schema=output_schema,
+            max_iterations=n_solutions_to_try,
+        )
+
+        plexe.save_model(model, "model-from-chat.tar.gz")
+
+        # For now, just return success status
+        return {
+            "status": "initiated",
+            "message": f"Model build started successfully with intent: '{intent}'",
+            "dataset_files": dataset_file_paths,
+            "dataset_shapes": [validation_results[path]["shape"] for path in dataset_file_paths],
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to initiate model build: {str(e)}")
+        return {"status": "failed", "message": f"Failed to start model build: {str(e)}", "error": str(e)}


### PR DESCRIPTION
This PR adds a simple "chat agent" to the library to enable a user to start the model building via a chat. The user should run

```python
python plexe/main.py
```

to start the chat. This will open a simple GradioUI that is suitable for testing. The chat agent itself is available in `plexe/agents/conversational.py` and can be hooked up into other front-ends etc.

This PR also deprecates (but does not remove) the `Model.build()` function. Until now, the `Model` class has been mixing two responsibilities:

1. Representing a model that can be used for inference, serialised, deserialised, etc
2. Wrapped the entire agent system that builds the models

The model building logic has been moved to a new class, `ModelBuilder`, which exposes a function `ModelBuilder.build() -> Model`. The `Model` class still has the `build` function for backwards compatibility, but this will be removed in a future version.