### PR TITLE
fix: improve safety of yaml serialisation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plexe"
-version = "0.23.5"
+version = "0.23.6"
 description = "An agentic framework for building ML models from natural language"
 authors = [
     "marcellodebernardi <marcello.debernardi@outlook.com>",


### PR DESCRIPTION
This PR makes two changes:

1. Add recursive handling to numpy arrays to avoid edge cases
2. Add a more robust fallback when type conversion doesn't work