### PR TITLE
hotfix: missing deprecated library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6749,4 +6749,4 @@ transformers = ["accelerate", "safetensors", "tokenizers", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "df3d635e13c9d594fcec321001b28fdb60dbca5be1d95405963ade2d5a7addd6"
+content-hash = "2bb901aa3be140acde4d16ba6a42dd8f44e2f870ca8678731335bababb3cdbfe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plexe"
-version = "0.26.0"
+version = "0.26.1"
 description = "An agentic framework for building ML models from natural language"
 authors = [
     "Marcello De Bernardi <mdebernardi@plexe.ai>",
@@ -52,6 +52,7 @@ ray = "^2.9.0"
 rich = "^13.7.1"
 torch = "^2.3.0"
 smolagents = "^1.14.0"
+deprecated = "^1.2.18"
 
 # Deep learning dependencies
 transformers = { version = "^4.50.0", optional = true }


### PR DESCRIPTION
The `deprecated` library is used in the project but was somehow missed in the latest release's dependencies.