### PR TITLE
fix: miscellaneous rewrite errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ notebooks/
 
 **/.claude/settings.local.json
 config.yaml
+Makefile.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH}
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Install pyspark extra
-RUN pip install --no-cache-dir 'pyspark>=4.0.1,<5.0.0'
+RUN pip install --no-cache-dir 'pyspark>=4.0.1,<4.1.0'
 
 # Download Spark JARs for S3 + Avro support (avoids ~40s Maven download at runtime)
 RUN mkdir -p /opt/spark-jars && \

--- a/Makefile
+++ b/Makefile
@@ -341,3 +341,6 @@ clean-images:
 .PHONY: clean
 clean: clean-workdir clean-images
 	@echo "✅ Full cleanup complete!"
+
+# Include local overrides (not committed to git)
+-include Makefile.local

--- a/plexe/CODE_INDEX.md
+++ b/plexe/CODE_INDEX.md
@@ -1,6 +1,6 @@
 # Code Index: plexe
 
-> Generated on 2026-02-08 21:45:49
+> Generated on 2026-02-09 15:35:33
 
 Code structure and public interface documentation for the **plexe** package.
 

--- a/plexe/config.py
+++ b/plexe/config.py
@@ -494,7 +494,7 @@ def setup_logging(config: Config) -> logging.Logger:
         Configured package logger
     """
     # Get package root logger
-    package_logger = logging.getLogger("source")
+    package_logger = logging.getLogger("plexe")
     package_logger.setLevel(getattr(logging, config.log_level.upper()))
 
     # Clear existing handlers to avoid duplicates

--- a/poetry.lock
+++ b/poetry.lock
@@ -3973,26 +3973,25 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyspark"
-version = "4.1.1"
+version = "4.0.2"
 description = "Apache Spark Python API"
 optional = true
-python-versions = ">=3.10"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"pyspark\""
 files = [
-    {file = "pyspark-4.1.1.tar.gz", hash = "sha256:77f78984aa84fbe865c717dd37b49913b4e5c97d76ef6824f932f1aefa6621ec"},
+    {file = "pyspark-4.0.2.tar.gz", hash = "sha256:938b4a1883383374d331ebfcb5d92debfa1891cf3d7a6d730520a1a2d23f1a90"},
 ]
 
 [package.dependencies]
 py4j = ">=0.10.9.7,<0.10.9.10"
 
 [package.extras]
-connect = ["googleapis-common-protos (>=1.71.0)", "grpcio (>=1.76.0)", "grpcio-status (>=1.76.0)", "numpy (>=1.21)", "pandas (>=2.2.0)", "pyarrow (>=15.0.0)", "zstandard (>=0.25.0)"]
+connect = ["googleapis-common-protos (>=1.65.0)", "grpcio (>=1.67.0)", "grpcio-status (>=1.67.0)", "numpy (>=1.21)", "pandas (>=2.0.0)", "pyarrow (>=11.0.0)"]
 ml = ["numpy (>=1.21)"]
 mllib = ["numpy (>=1.21)"]
-pandas-on-spark = ["numpy (>=1.21)", "pandas (>=2.2.0)", "pyarrow (>=15.0.0)"]
-pipelines = ["googleapis-common-protos (>=1.71.0)", "grpcio (>=1.76.0)", "grpcio-status (>=1.76.0)", "numpy (>=1.21)", "pandas (>=2.2.0)", "pyarrow (>=15.0.0)", "pyyaml (>=3.11)", "zstandard (>=0.25.0)"]
-sql = ["numpy (>=1.21)", "pandas (>=2.2.0)", "pyarrow (>=15.0.0)"]
+pandas-on-spark = ["numpy (>=1.21)", "pandas (>=2.0.0)", "pyarrow (>=11.0.0)"]
+sql = ["numpy (>=1.21)", "pandas (>=2.0.0)", "pyarrow (>=11.0.0)"]
 
 [[package]]
 name = "pytest"
@@ -5967,4 +5966,4 @@ pyspark = ["pyspark"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "91dc974facc032fe3e3671ea88d0b049ed645baae2f74d4345fb7f6f40afb8b0"
+content-hash = "be497053105e160a447720c8c6dee9308c311b1ea86dc19b694d46e3967d77a8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plexe"
-version = "1.0.0"
+version = "1.0.1"
 description = "An agentic framework for building ML models from natural language"
 authors = [
     "Marcello De Bernardi <mdebernardi@plexe.ai>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ pydantic = ">=2.7.4,<3.0.0"
 pydantic-settings = ">=2.0.0,<3.0.0"
 
 # Optional dependencies
-pyspark = { version = ">=4.0.1,<5.0.0", optional = true }
+pyspark = { version = ">=4.0.1,<4.1.0", optional = true }
 databricks-connect = { version = ">=17.3.1,<18.0.0", python = "3.12", optional = true }
 boto3 = { version = ">=1.35.0,<2.0.0", optional = true }
 

--- a/tests/CODE_INDEX.md
+++ b/tests/CODE_INDEX.md
@@ -1,6 +1,6 @@
 # Code Index: tests
 
-> Generated on 2026-02-08 21:45:49
+> Generated on 2026-02-09 15:35:33
 
 Test suite structure and test case documentation.
 


### PR DESCRIPTION
This PR makes a few miscellaneous tweaks and fixes that were missed in the `1.0.0` rewrite (see #161). Namely:

1. Add support for `Makefile.local`
2. Fix the version bound on `pyspark` (too loose, resulted in a regression when the version got upgraded)
3. An error in the logging configuration