### PR TITLE
chore: ignore .claude and .codex directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,7 +201,6 @@ examples/datasets/**/_SUCCESS
 experiments/
 notebooks/
 
-**/.claude/settings.local.json
 .claude/
 .codex/
 config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -202,5 +202,7 @@ experiments/
 notebooks/
 
 **/.claude/settings.local.json
+.claude/
+.codex/
 config.yaml
 Makefile.local


### PR DESCRIPTION
This PR adds directory-level ignore rules for .claude/ and .codex/ in .gitignore. The aim is to prevent local agent/editor metadata folders from being accidentally committed while keeping the repository clean for all contributors.

## Testing
- git check-ignore -v .claude/test.txt .codex/test.txt
