### PR TITLE
fix(dashboard): discover experiments in flat work-dir layout

### DIFF
--- a/plexe/utils/dashboard/discovery.py
+++ b/plexe/utils/dashboard/discovery.py
@@ -1,7 +1,10 @@
 """
 Experiment discovery and metadata extraction for dashboard.
 
-Scans workdir at correct depth (dataset_name/timestamp/) and loads checkpoint metadata.
+Scans at flat, 1-level, or 2-level depth:
+- workdir/checkpoints/ (flat — default standalone local runs)
+- workdir/{dataset_name}/checkpoints/ (1-level)
+- workdir/{dataset_name}/{timestamp}/checkpoints/ (2-level)
 """
 
 import json
@@ -56,6 +59,19 @@ def discover_experiments(workdir: Path) -> list[ExperimentMetadata]:
     if not workdir.exists():
         logger.warning(f"Workdir does not exist: {workdir}")
         return experiments
+
+    # Flat layout: checkpoints/ directly under workdir (standalone local runs)
+    if (workdir / "checkpoints").is_dir():
+        try:
+            experiments.append(
+                _extract_metadata(
+                    dataset_name=workdir.name,
+                    timestamp=workdir.name,
+                    experiment_path=workdir,
+                )
+            )
+        except Exception as e:
+            logger.warning(f"Failed to extract metadata from {workdir}: {e}")
 
     # Scan first level (dataset names)
     for dataset_dir in workdir.iterdir():
@@ -134,13 +150,16 @@ def _extract_metadata(dataset_name: str, timestamp: str, experiment_path: Path) 
     }
 
     current_phase = latest_checkpoint.get("phase")
-    phase_number = phase_map.get(current_phase, 0)
+    phase_key = (
+        current_phase.split("_", 1)[1] if current_phase and current_phase.split("_", 1)[0].isdigit() else current_phase
+    )
+    phase_number = phase_map.get(phase_key, 0)
 
     # Determine status
     checkpoint_status = latest_checkpoint.get("status", "completed")
     if checkpoint_status == "in_progress":
         status = "running"
-    elif current_phase == "package_final_model" and checkpoint_status == "completed":
+    elif phase_key == "package_final_model" and checkpoint_status == "completed":
         status = "completed"
     else:
         # Check if there's an error or if it looks abandoned

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plexe"
-version = "1.4.4"
+version = "1.4.5"
 description = "An agentic framework for building ML models from natural language"
 authors = [
     "Marcello De Bernardi <mdebernardi@plexe.ai>",

--- a/tests/unit/utils/dashboard/test_discovery.py
+++ b/tests/unit/utils/dashboard/test_discovery.py
@@ -1,0 +1,45 @@
+"""Unit tests for dashboard experiment discovery."""
+
+import json
+from pathlib import Path
+
+from plexe.utils.dashboard.discovery import discover_experiments
+
+
+def _write_checkpoint(checkpoints_dir: Path, filename: str, phase: str, intent: str = "test intent") -> None:
+    checkpoints_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "phase": phase,
+        "status": "completed",
+        "context": {
+            "intent": intent,
+            "experiment_id": "local",
+            "metric": {"name": "roc_auc"},
+        },
+    }
+    (checkpoints_dir / filename).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_discover_flat_workdir_layout(tmp_path: Path) -> None:
+    """Standalone runs write checkpoints/ directly under --work-dir."""
+    _write_checkpoint(tmp_path / "checkpoints", "06_package_final_model.json", "06_package_final_model")
+
+    experiments = discover_experiments(tmp_path)
+
+    assert len(experiments) == 1
+    assert experiments[0].path == tmp_path
+    assert experiments[0].phase_number == 6
+    assert experiments[0].status == "completed"
+    assert experiments[0].intent == "test intent"
+
+
+def test_discover_nested_one_level_layout(tmp_path: Path) -> None:
+    """Nested dataset folders remain discoverable."""
+    exp_dir = tmp_path / "weatherAUS"
+    _write_checkpoint(exp_dir / "checkpoints", "03_build_baselines.json", "03_build_baselines")
+
+    experiments = discover_experiments(tmp_path)
+
+    assert len(experiments) == 1
+    assert experiments[0].path == exp_dir
+    assert experiments[0].phase_number == 3


### PR DESCRIPTION
## Summary

Fixes the Streamlit dashboard not listing experiments when using the default standalone local work directory layout.

- Detect `workdir/checkpoints/` directly under `--work-dir` (flat layout used by `plexe.main`)
- Normalize numbered checkpoint phase names (e.g. `06_package_final_model`) when inferring phase number and completion status

## Problem

`python -m plexe.main --work-dir ./plexe_workdir ...` writes artifacts to:

```
plexe_workdir/
├── checkpoints/
├── model/
└── .build/
```

But `python -m plexe.viz --work-dir ./plexe_workdir` reported **"No experiments found"** because `discover_experiments()` only scanned nested paths like `workdir/{dataset_name}/checkpoints/`.

Reproduced after a successful end-to-end build on the Rain in Australia dataset (weatherAUS, PyPI 1.4.4, Python 3.12).

## Fix

- Add flat-layout detection when `workdir/checkpoints/` exists
- Strip numeric prefix from checkpoint `phase` before phase/status mapping so completed runs show correctly

## Test plan

- [x] `poetry run pytest tests/unit/utils/dashboard/test_discovery.py -v`
- [x] `poetry run pytest tests/unit/ -q`
- [x] Manually verified `discover_experiments(Path("./plexe_workdir_clean"))` returns 1 experiment
- [x] Manually verified `python -m plexe.viz --work-dir ./plexe_workdir_clean` lists the experiment in the sidebar
